### PR TITLE
feat(1): create dead letter queue for scraping queue

### DIFF
--- a/sls/resources/sqs/scrapingQueue.yml
+++ b/sls/resources/sqs/scrapingQueue.yml
@@ -6,3 +6,15 @@ Resources:
       QueueName: ${self:service}-scraping-queue.fifo # must end with .fifo suffix
       VisibilityTimeout: 600 # 10 minutes
       ContentBasedDeduplication: false
+      RedrivePolicy: 
+        deadLetterTargetArn: !GetAtt ScrapingDLQueue.Arn
+        maxReceiveCount: 3
+
+  ScrapingDLQueue:
+    Type: AWS::SQS::Queue
+    Properties: 
+      FifoQueue: true
+      QueueName: ${self:service}-scraping-dl-queue.fifo # must end with .fifo suffix
+      MessageRetentionPeriod: 1209600 # 14 days
+      VisibilityTimeout: 60 # 1 minute
+      ContentBasedDeduplication: false


### PR DESCRIPTION
Definição da DLQueue para a fila de Scraping.
No máximo 3 tentativas de crawl antes de ser mandado para a dead letter. A DLQueue tem retenção de 14 dias (máximo) e VisibilityTimeout de um minuto (para não correr o risco de retirar a mesma mensagem duas vezes da fila).

Os logs de recursos SQS são exportados por padrão para o CloudWatch, não sendo necessário habilitar configurações para ver a quantidade de mensagens visíveis na fila.