### PR TITLE
Revert "bugfix(18): change multiply to divide at the ideal cluster equation"

### DIFF
--- a/src/functions/scripts/orchestrateInstances.js
+++ b/src/functions/scripts/orchestrateInstances.js
@@ -190,7 +190,7 @@ export async function main (event) {
       );
 
       if (approximateNumberOfMessages) {
-        const idealClusterSize = Math.ceil((approximateNumberOfMessages * averageClusterServiceTime) / (sla / parallelProcessingCapacity));
+        const idealClusterSize = Math.ceil((approximateNumberOfMessages * averageClusterServiceTime) / (sla * parallelProcessingCapacity));
 
         const newClusterSize = Math.min(maximumClusterSize, idealClusterSize);
 


### PR DESCRIPTION
Reverts PradoTPS/aws-scraper-cost-optimization#19

Revert pull request because we need to multiply, not divide.